### PR TITLE
SF-26 : Integrate forgot-password in Login Page

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -3,7 +3,7 @@ import { Mail, Lock } from "lucide-react";
 import Button from "../components/ui/Button";
 import Logo from "../components/Logo";
 import axios from "axios";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 const Login: React.FC = () => {
   const [email, setEmail] = useState("");
@@ -117,12 +117,12 @@ const Login: React.FC = () => {
             </div>
 
             <div className="text-sm">
-              <a
-                href="#"
+              <Link
+                to="/forgot-password"
                 className="font-medium text-blue-400 hover:text-blue-300"
               >
                 Forgot your password?
-              </a>
+              </Link>
             </div>
           </div>
 


### PR DESCRIPTION
# Description

 Integrate forgot-password in Login Page

Jira Issue [#SF-26](https://app.clickup.com/t/86cyx4894)


## Type of change


- [X] Bug fix (non-breaking change which fixes an issue)

When user clicks Forgot your password link in the login page it redirects to the Forgot-password page. Below is the screenshot attached.

![image](https://github.com/user-attachments/assets/0ae889a2-111a-4802-8505-ff2732165624)



# Checklist:

- [X] I Have mentioned in the title of the PR the related Jira Issue
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings

